### PR TITLE
examples: fix example invocation in README

### DIFF
--- a/c_examples/README.md
+++ b/c_examples/README.md
@@ -4,5 +4,5 @@ This crate contains an example on how to use the C API
 
 Run with
 ```
-cargo run --example lstypec --backend sysfs
+cargo run -p c_examples --example lstypec -- --backend sysfs
 ```

--- a/c_examples/lstypec.rs
+++ b/c_examples/lstypec.rs
@@ -7,7 +7,6 @@
 use argh::FromArgs;
 use libtypec_rs::typec::OsBackends;
 
-#[link(name = "c_examples_lstypec")]
 extern "C" {
     fn c_example_lstypec(backend: u32) -> std::ffi::c_int;
 }


### PR DESCRIPTION
The example was moved into its own crate, but the README was not updated to reflect this change.

Remove the link name attribute while we are at it. It is not needed, as the cc crate will automatically make the compiled symbols available to the rest of the Rust code.